### PR TITLE
Invariant imprecision identification methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 [![Build Status][build_img]][travis]
 
+CHANGED FILES
+=============
+ssa\_analyzer.h
+ssa\_analyzer.cpp
+domain.h
+heap\_domain.h
+heap\_domain.cpp
+
+
 About
 =====
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,5 @@
 [![Build Status][build_img]][travis]
 
-CHANGED FILES
-=============
-ssa\_analyzer.h
-ssa\_analyzer.cpp
-domain.h
-heap\_domain.h
-heap\_domain.cpp
-
-
 About
 =====
 

--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -336,10 +336,8 @@ void twols_parse_optionst::get_command_line_options(optionst &options)
     options.set_option("graphml-witness", cmdline.get_value("graphml-witness"));
   if(cmdline.isset("json-cex"))
     options.set_option("json-cex", cmdline.get_value("json-cex"));
-  // TODO ------------------------------------
   if(cmdline.isset("show-imprecise-vars"))
     options.set_option("show-imprecise-vars", true);
-  // -----------------------------------------
 }
 
 /// invoke main modules

--- a/src/2ls/2ls_parse_options.cpp
+++ b/src/2ls/2ls_parse_options.cpp
@@ -336,6 +336,10 @@ void twols_parse_optionst::get_command_line_options(optionst &options)
     options.set_option("graphml-witness", cmdline.get_value("graphml-witness"));
   if(cmdline.isset("json-cex"))
     options.set_option("json-cex", cmdline.get_value("json-cex"));
+  // TODO ------------------------------------
+  if(cmdline.isset("show-imprecise-vars"))
+    options.set_option("show-imprecise-vars", true);
+  // -----------------------------------------
 }
 
 /// invoke main modules
@@ -1519,6 +1523,7 @@ void twols_parse_optionst::help()
     " --round-to-plus-inf          IEEE floating point rounding mode\n"
     " --round-to-minus-inf         IEEE floating point rounding mode\n"
     " --round-to-zero              IEEE floating point rounding mode\n"
+    " --show-imprecise-vars        show imprecise variables inside invariant\n"
     "\n"
     "Program instrumentation options:\n"
     GOTO_CHECK_HELP

--- a/src/2ls/2ls_parse_options.h
+++ b/src/2ls/2ls_parse_options.h
@@ -61,7 +61,7 @@ class optionst;
   "(preconditions)(sufficient)" \
   "(show-locs)(show-vcc)(show-properties)(trace)(show-stats)" \
   "(show-goto-functions)(show-guards)(show-defs)(show-ssa)(show-assignments)" \
-  "(show-invariants)(std-invariants)" \
+  "(show-invariants)(std-invariants)(show-imprecise-vars)" \
   "(property):(all-properties)(k-induction)(incremental-bmc)" \
   "(no-spurious-check)(all-functions)" \
   "(no-simplify)(no-fixed-point)" \

--- a/src/domains/domain.h
+++ b/src/domains/domain.h
@@ -303,13 +303,8 @@ public:
     const var_specst &var_specs,
     const namespacet &ns);
 
-  // TODO --------------------------------------------------------
-  virtual std::vector<std::string> identify_invariant_imprecision(
-    const valuet &value)
-  { 
-    return {}; 
-  }
-  // -------------------------------------------------------------
+  virtual std::vector<std::string>
+    identify_invariant_imprecision(const valuet &value) { return {}; }
 
 protected:
   unsigned domain_number; // serves as id for variables names

--- a/src/domains/domain.h
+++ b/src/domains/domain.h
@@ -303,6 +303,14 @@ public:
     const var_specst &var_specs,
     const namespacet &ns);
 
+  // TODO --------------------------------------------------------
+  virtual std::vector<std::string> identify_invariant_imprecision(
+    const valuet &value)
+  { 
+    return {}; 
+  }
+  // -------------------------------------------------------------
+
 protected:
   unsigned domain_number; // serves as id for variables names
   replace_mapt &renaming_map;

--- a/src/domains/heap_domain.cpp
+++ b/src/domains/heap_domain.cpp
@@ -1473,48 +1473,34 @@ const exprt heap_domaint::get_points_to_dest(
   else
     return nil_exprt();
 }
-/*******************************************************************\
 
-Function: heap_domaint::identify_invariant_imprecision
-
-  Inputs: Computed invariant
-
- Outputs: Vector of imprecise SSA variable names
-
- Purpose: Identify imprecise template variables of invariant
-
-\*******************************************************************/
+/// Identify imprecise template variables of invariant
+/// \param value: Computed invariant
+/// \return Vector of imprecise SSA variable names
 std::vector<std::string> heap_domaint::identify_invariant_imprecision(
   const domaint::valuet &value)
 {
-  // get corresponding template row values
+  // Get the corresponding template row values
   const heap_valuet &val=static_cast<const heap_valuet &>(value);
   assert(val.size()==templ.size());
 
-  // vector for saving ssa variable names
+  // Vector of ssa variable names
   std::vector<std::string> ssa_vars;
- 
-  for (rowt row=0; row<templ.size(); row++)
+
+  for(rowt row=0; row<templ.size(); ++row)
   {
-    exprt row_expr=templ[row].expr;
-    const exprt row_val=val[row].get_row_expr(row_expr, false);
-    
-    // row value is nondeterministic
-    if (row_val.is_true()) 
+    const exprt &row_expr=templ[row].expr;
+    const exprt &row_val=val[row].get_row_expr(row_expr, false);
+
+    // Row value is nondeterministic
+    if(row_val.is_true())
     {
-      // Only template expressions that are of symbol type
-      if (row_expr.id()!=ID_symbol)
-        continue;
-
-      // the template row expression variable name
-      std::string expr_name=from_expr(domaint::ns, "", row_expr);
-
-//      debug() << ssa_vars.size()+1 << ": " << expr_name << "\n";
-//        << "\tValue: " << from_expr(domaint::ns, "", row_val) << "\n";
-
-      ssa_vars.push_back(expr_name);
+      // skip any CPROVER symobls
+      if(row_expr.id()==ID_symbol && !is_cprover_symbol(row_expr))
+        ssa_vars.push_back(from_expr(domaint::ns, "", row_expr));
     }
   }
 
   return ssa_vars;
 }
+

--- a/src/domains/heap_domain.cpp
+++ b/src/domains/heap_domain.cpp
@@ -1473,3 +1473,48 @@ const exprt heap_domaint::get_points_to_dest(
   else
     return nil_exprt();
 }
+/*******************************************************************\
+
+Function: heap_domaint::identify_invariant_imprecision
+
+  Inputs: Computed invariant
+
+ Outputs: Vector of imprecise SSA variable names
+
+ Purpose: Identify imprecise template variables of invariant
+
+\*******************************************************************/
+std::vector<std::string> heap_domaint::identify_invariant_imprecision(
+  const domaint::valuet &value)
+{
+  // get corresponding template row values
+  const heap_valuet &val=static_cast<const heap_valuet &>(value);
+  assert(val.size()==templ.size());
+
+  // vector for saving ssa variable names
+  std::vector<std::string> ssa_vars;
+ 
+  for (rowt row=0; row<templ.size(); row++)
+  {
+    exprt row_expr=templ[row].expr;
+    const exprt row_val=val[row].get_row_expr(row_expr, false);
+    
+    // row value is nondeterministic
+    if (row_val.is_true()) 
+    {
+      // Only template expressions that are of symbol type
+      if (row_expr.id()!=ID_symbol)
+        continue;
+
+      // the template row expression variable name
+      std::string expr_name=from_expr(domaint::ns, "", row_expr);
+
+//      debug() << ssa_vars.size()+1 << ": " << expr_name << "\n";
+//        << "\tValue: " << from_expr(domaint::ns, "", row_val) << "\n";
+
+      ssa_vars.push_back(expr_name);
+    }
+  }
+
+  return ssa_vars;
+}

--- a/src/domains/heap_domain.h
+++ b/src/domains/heap_domain.h
@@ -265,10 +265,8 @@ public:
     return templ.empty();
   }
 
-  // TODO --------------------------------------------------------
-  virtual std::vector<std::string> identify_invariant_imprecision(
-    const valuet &value) override;
-  // -------------------------------------------------------------
+  virtual std::vector<std::string>
+    identify_invariant_imprecision(const valuet &value) override;
 
 protected:
   templatet templ;

--- a/src/domains/heap_domain.h
+++ b/src/domains/heap_domain.h
@@ -265,6 +265,11 @@ public:
     return templ.empty();
   }
 
+  // TODO --------------------------------------------------------
+  virtual std::vector<std::string> identify_invariant_imprecision(
+    const valuet &value) override;
+  // -------------------------------------------------------------
+
 protected:
   templatet templ;
 

--- a/src/domains/heap_tpolyhedra_domain.cpp
+++ b/src/domains/heap_tpolyhedra_domain.cpp
@@ -120,39 +120,32 @@ void heap_tpolyhedra_domaint::set_smt_values(
 {
 }
 
-/*******************************************************************\
-
-Function: heap_tpolyhedra_domaint::identify_invariant_imprecision
-
-  Inputs: TODO
-
- Outputs: TODO
-
- Purpose: TODO
-
-\*******************************************************************/
-std::vector<std::string> heap_tpolyhedra_domaint::identify_invariant_imprecision(
+/// Identify imprecise template variables inside invariant
+/// \return Vector of imprecise SSA variable names
+std::vector<std::string>
+  heap_tpolyhedra_domaint::identify_invariant_imprecision(
   const domaint::valuet &value)
 {
   const heap_tpolyhedra_valuet &v=
     static_cast<const heap_tpolyhedra_valuet &>(value);
 
-  // invariant identif imprecision for both 'sub-domains'
-  // heap domain variables
-  std::vector<std::string> ssa_vars=heap_domain.identify_invariant_imprecision(
-    v.heap_value);
+  // Identify imprecise variables for both 'sub-domains'
 
-  // tpolyhedra domain variables
+  //  Get heap domain imprecise template variables
+  std::vector<std::string> heap_vars=
+    heap_domain.identify_invariant_imprecision(v.heap_value);
+
+  //  Get tpolyhedra domain imprecise template variables
   std::vector<std::string> tpoly_vars=
     polyhedra_domain.identify_invariant_imprecision(v.tpolyhedra_value);
 
-  // concatenate vectors
-  ssa_vars.reserve(ssa_vars.size() + tpoly_vars.size());
-  ssa_vars.insert(
-    ssa_vars.end(),
+  //  Concatenate vectors of imprecise variables of both domain
+  heap_vars.reserve(heap_vars.size()+tpoly_vars.size());
+  heap_vars.insert(
+    heap_vars.end(),
     std::make_move_iterator(tpoly_vars.begin()),
-    std::make_move_iterator(tpoly_vars.end())
-  );
+    std::make_move_iterator(tpoly_vars.end()));
 
-  return ssa_vars;
+  return heap_vars;
 }
+

--- a/src/domains/heap_tpolyhedra_domain.cpp
+++ b/src/domains/heap_tpolyhedra_domain.cpp
@@ -119,3 +119,40 @@ void heap_tpolyhedra_domaint::set_smt_values(
   size_t row)
 {
 }
+
+/*******************************************************************\
+
+Function: heap_tpolyhedra_domaint::identify_invariant_imprecision
+
+  Inputs: TODO
+
+ Outputs: TODO
+
+ Purpose: TODO
+
+\*******************************************************************/
+std::vector<std::string> heap_tpolyhedra_domaint::identify_invariant_imprecision(
+  const domaint::valuet &value)
+{
+  const heap_tpolyhedra_valuet &v=
+    static_cast<const heap_tpolyhedra_valuet &>(value);
+
+  // invariant identif imprecision for both 'sub-domains'
+  // heap domain variables
+  std::vector<std::string> ssa_vars=heap_domain.identify_invariant_imprecision(
+    v.heap_value);
+
+  // tpolyhedra domain variables
+  std::vector<std::string> tpoly_vars=
+    polyhedra_domain.identify_invariant_imprecision(v.tpolyhedra_value);
+
+  // concatenate vectors
+  ssa_vars.reserve(ssa_vars.size() + tpoly_vars.size());
+  ssa_vars.insert(
+    ssa_vars.end(),
+    std::make_move_iterator(tpoly_vars.begin()),
+    std::make_move_iterator(tpoly_vars.end())
+  );
+
+  return ssa_vars;
+}

--- a/src/domains/heap_tpolyhedra_domain.h
+++ b/src/domains/heap_tpolyhedra_domain.h
@@ -87,10 +87,8 @@ public:
 
   bool edit_row(const rowt &row, valuet &inv, bool improved);
 
-  // TODO --------------------------------------------------------
-  virtual std::vector<std::string> identify_invariant_imprecision(
-    const valuet &value) override;
-  // -------------------------------------------------------------
+  virtual std::vector<std::string>
+    identify_invariant_imprecision(const valuet &value) override;
 };
 
 #endif // CPROVER_2LS_DOMAINS_HEAP_TPOLYHEDRA_DOMAIN_H

--- a/src/domains/heap_tpolyhedra_domain.h
+++ b/src/domains/heap_tpolyhedra_domain.h
@@ -86,6 +86,11 @@ public:
     exprt::operandst &cond_exprs);
 
   bool edit_row(const rowt &row, valuet &inv, bool improved);
+
+  // TODO --------------------------------------------------------
+  virtual std::vector<std::string> identify_invariant_imprecision(
+    const valuet &value) override;
+  // -------------------------------------------------------------
 };
 
 #endif // CPROVER_2LS_DOMAINS_HEAP_TPOLYHEDRA_DOMAIN_H

--- a/src/domains/heap_tpolyhedra_sympath_domain.cpp
+++ b/src/domains/heap_tpolyhedra_sympath_domain.cpp
@@ -84,3 +84,32 @@ void heap_tpolyhedra_sympath_domaint::set_smt_values(
   size_t row)
 {
 }
+
+/// Identify imprecise template variables inside invariant
+/// \return Vector of imprecise SSA variable names
+std::vector<std::string>
+  heap_tpolyhedra_sympath_domaint::identify_invariant_imprecision(
+  const domaint::valuet &value)
+{
+  const heap_tpolyhedra_sympath_valuet &v=
+    static_cast<const heap_tpolyhedra_sympath_valuet &>(value);
+
+  // Imprecise SSA variable names
+  std::vector<std::string> ssa_vars;
+
+  for(auto &config : v)
+  {
+    std::vector<std::string> ids=
+      heap_tpolyhedra_domain.identify_invariant_imprecision(config.second);
+
+    // Concatenate with previously found names
+    ssa_vars.reserve(ssa_vars.size()+ids.size());
+    ssa_vars.insert(
+      ssa_vars.end(),
+      std::make_move_iterator(ids.begin()),
+      std::make_move_iterator(ids.end()));
+  }
+
+  return ssa_vars;
+}
+

--- a/src/domains/heap_tpolyhedra_sympath_domain.h
+++ b/src/domains/heap_tpolyhedra_sympath_domain.h
@@ -73,6 +73,9 @@ public:
 
   bool edit_row(const rowt &row, valuet &inv, bool improved);
 
+  virtual std::vector<std::string>
+    identify_invariant_imprecision(const valuet &value) override;
+
 protected:
   // Special path containing conjunction negations of all loop-select guards
   // This must be stored explicitly since the solver is not able to explore this

--- a/src/domains/ssa_analyzer.cpp
+++ b/src/domains/ssa_analyzer.cpp
@@ -20,6 +20,7 @@ Author: Peter Schrammel
 #include <util/simplify_expr.h>
 #include <util/mp_arith.h>
 #include <util/options.h>
+#include <util/cprover_prefix.h>
 
 #include "strategy_solver_base.h"
 #include "strategy_solver_binsearch.h"
@@ -47,8 +48,6 @@ Author: Peter Schrammel
   *static_cast<tpolyhedra_domaint *>(domain), solver, SSA, SSA.ns)
 #endif
 
-// TODO dynamic object prefix string length
-#define DYN_PRFX_LEN 16
 
 void ssa_analyzert::operator()(
   incremental_solvert &solver,
@@ -195,18 +194,16 @@ void ssa_analyzert::operator()(
   solver_calls+=s_solver->get_number_of_solver_calls();
   solver_instances+=s_solver->get_number_of_solver_instances();
 
-
-  // TODO ----------------------------------------------------
+  // imprecision identification
   if(template_generator.options.get_bool_option("show-imprecise-vars"))
   {
-    // getting imprecise ssa variables' names
+    // get imprecise SSA variable names
     std::vector<std::string> ssa_vars=
       domain->identify_invariant_imprecision(*result);
 
-    // printing out imprecise variables and their real locations
+    // link the variables to the exact goto instuctions
     find_goto_instrs(SSA, ssa_vars);
   }
-  // ---------------------------------------------------------
 
   delete s_solver;
 }
@@ -229,178 +226,94 @@ const exprt ssa_analyzert::input_heap_bindings()
   return static_cast<heap_domaint &>(*domain).get_iterator_bindings();
 }
 
-/*******************************************************************\
-
-Function: ssa_analyzert::find_goto_instrs
-
-  Inputs: Local SSA, vector of SSA loop back variable names
-
- Outputs: 
-
- Purpose: Map the SSA variable names back to the source program.
-
-\*******************************************************************/
+/// Save the source code information about the variables into
+///   the summary of imprecise variables
+/// \param SSA: Local SSA
+/// \param ssa_vars: Vector of imprecise SSA loop back variable names
 void ssa_analyzert::find_goto_instrs(
-  local_SSAt &SSA, 
-  std::vector<std::string> &ssa_vars)
+  local_SSAt &SSA,
+  const std::vector<std::string> &ssa_vars)
 {
-  vars_summary.resize(ssa_vars.size());
-  imprecise_varst::iterator summary_it=vars_summary.begin();
+  imprecise_vars_summary.resize(ssa_vars.size());
+  imprecise_varst::iterator summary_it=imprecise_vars_summary.begin();
 
-  for (auto &var : ssa_vars)
+  for(auto &var : ssa_vars)
   {
-    // heap domain specific, dynamic objects, starts with string
-    bool is_dynamic=((var.compare(0, DYN_PRFX_LEN-1, "dynamic_object$"))==0);
+    bool is_dynamic=false;
 
-    // get location of SSA var
-    int loc=get_name_loc(var);
-
-    // get the pretty name of the imprecise ssa var
-    summary_it->pretty_name=get_pretty_name(var);
-    // std::string var_pretty=get_pretty_name(var);
-
-    // location could not be parsed from the variable name
-    if (loc==-1)
+    // save the real name of variables into the summary
+    if(is_dynamic_name(var))
     {
-      // summary_it->loophead_loc=-1;
-      // debug() << "Input variable: \"" << var_pretty << "\"\n"; TODO
-      continue;
+      summary_it->pretty_name=get_dynobj_name(var);
+      is_dynamic=true;
     }
+    else
+      summary_it->pretty_name=get_original_name(var);
 
-    // get SSA node on that location - end of the loop for loop-back var
-    local_SSAt::nodest::iterator lb_node=SSA.find_node(
-      SSA.get_location(static_cast<unsigned>(loc)));
+    int node_loc=get_name_node_loc(var);
 
-    // get start of the loop node (loop-head node) for that loop-back node
-    local_SSAt::nodest::iterator lh_node=lb_node->loophead;
-
-    // heap dynamic objects
-    if (is_dynamic)
+    // Node location of loop back variables is known
+    if(node_loc!=-1)
     {
-      summary_it->dyn_mem_field=get_dynamic_field(var);
+      // get the actual loop back node in the local SSA
+      local_SSAt::nodest::iterator lb_node=SSA.find_node(
+        SSA.get_location(static_cast<unsigned>(node_loc)));
 
-      // debug() << "Imprecise value of \"" << get_dynamic_field(var) TODO
-      //  << "\" field of \"" << var_pretty << "\" allocated at line ";
+      // save the source location of the loop head node in the summary
+      local_SSAt::nodest::iterator lh_node=lb_node->loophead;
+      summary_it->loophead_line=lh_node->location->source_location.get_line();
 
-      // get the object's allocation location
-      int field_loc=get_field_loc(var);
-
-      // location could not be parsed from its name
-      if (field_loc==-1)
-        summary_it->dyn_alloc_loc="<NOT FOUND>"; //  debug() << "<NOT FOUND>"; TODO
-      else
+      // for dynamic objects additionally we save:
+      //  allocation site location
+      //  if structured-typed then its structure field
+      if(is_dynamic)
       {
-        summary_it->dyn_alloc_loc=(
-          SSA.find_node(
-            SSA.get_location(static_cast<unsigned>(field_loc))
-          ))->location->source_location.get_line();
+        int node_line=get_dynobj_line(var);
+
+        summary_it->dyn_alloc_line=node_line==-1
+          ? "<UNKNOWN>"
+          : (SSA.find_node(SSA.get_location(static_cast<unsigned>(node_line))))
+              ->location->source_location.get_line();
+
+        summary_it->dyn_mem_field=get_dynamic_field(var);
       }
     }
-    // static variables
-    else 
-    {
-      // debug() << "Imprecise value of variable \"" << var_pretty << '"';
-    }
-    summary_it->loophead_loc=lh_node->location->source_location.get_line();
-    // debug() << " at the end of the loop, that starts at line "
-    //  << lh_node->location->source_location.get_line() << '\n';
+
     summary_it++;
   }
 }
 
-/*******************************************************************\
-
-Function: ssa_analyzert::get_name_loc(const std::string &name)
-
-  Inputs: SSA loop back variable name.
-
- Outputs: Location of the node in the local SSA.
-
- Purpose: Extract the node location from its ssa name.
-
-\*******************************************************************/
-int ssa_analyzert::get_name_loc(const std::string &name)
+/// Get only the dynamic object name: "dynamic_object$i#y"
+/// \param name: SSA loop-back Dynamic object name
+/// \return SSA dynamic object name without its field and anything after
+std::string ssa_analyzert::get_dynobj_name(const std::string &name)
 {
-  // find last occurnce of "#lb"
-  size_t idx=name.rfind("#lb");
+  size_t idx;
+
+  // is structure-typed object ->
+  //  get the part right before the object field
+  if((idx=name.find('.', DYN_PREFIX_LEN))!=std::string::npos)
+    return name.substr(0, idx);
+  // remove everything after loop back part of the string
+  else if((idx=is_loopback_var(name))!=std::string::npos)
+    return name.substr(0, idx);
+  else
+    return name;
+}
+
+/// Extract the node location from its ssa name.
+/// \param name: SSA loop back variable name.
+/// \return Location of the node in the local SSA.
+int ssa_analyzert::get_name_node_loc(const std::string &name)
+{
+  // is not a loop back variable -> has unknown location
+  size_t idx=is_loopback_var(name);
   if(idx==std::string::npos)
     return -1;
 
-  //std::string loc_str=name.substr(name.find_last_not_of("0123456789")+1);
+  // get the location number after '#lb'
   std::string loc_str=name.substr(idx+3);
   assert(!loc_str.empty());
   return std::stoi(loc_str);
 }
 
-/*******************************************************************\
-
-Function: ssa_analyzert::get_pretty_name(const std::string &name)
-
-  Inputs: SSA loop back variable name.
-
- Outputs: Pretty name of the SSA variable (only the part before '#').
-
- Purpose: Strip the name of the part after '#' (and the '#' as well).
-
-\*******************************************************************/
-std::string ssa_analyzert::get_pretty_name(const std::string &name)
-{
-  std::string pretty(name);
-  size_t idx=name.find('#');
-
-  if(idx!=std::string::npos)
-    pretty=name.substr(0, idx);
-  
-  return pretty;
-}
-
-/*******************************************************************\
-
-Function: ssa_analyzert::get_field_loc(const std::string &name)
-
-  Inputs: SSA loop back dynamic variable name.
-
- Outputs: Location of the field in the local SSA.
-
- Purpose: Extract the field location from its SSA name.
-
-\*******************************************************************/
-int ssa_analyzert::get_field_loc(const std::string &name)
-{
-  size_t field_pos=name.find_last_of('$');
-  if (field_pos==std::string::npos)
-    return -1;
-
-  std::string loc_str=name.substr(field_pos+1);
-  return std::stoi(loc_str);
-}
-
-/*******************************************************************\
-
-Function: ssa_analyzert::get_dynamic_field(const std::string &name)
-
-  Inputs: SSA loop back dynamic object name.
-
- Outputs: Member of the dynamic object.
-
- Purpose: Extract the member field from the dynamic object name.
-
-\*******************************************************************/
-std::string ssa_analyzert::get_dynamic_field(const std::string &name)
-{
-  // only dynamic objects: expecting dollar sign at pos 14
-  assert(name[DYN_PRFX_LEN-2]=='$');
-
-  std::string not_found ("<NO MEMBER>");
-
-  size_t dot_pos=name.find_last_of('.');
-  size_t hash_pos=name.find_last_of('#');
-  if (dot_pos==std::string::npos || hash_pos==std::string::npos)
-    return not_found;
-
-  std::string loc_str=name.substr(dot_pos+1, hash_pos-dot_pos-1);
-  if (loc_str.empty())
-    return not_found;
-
-  return loc_str;
-}

--- a/src/domains/ssa_analyzer.cpp
+++ b/src/domains/ssa_analyzer.cpp
@@ -192,6 +192,23 @@ void ssa_analyzert::operator()(
   solver_calls+=s_solver->get_number_of_solver_calls();
   solver_instances+=s_solver->get_number_of_solver_instances();
 
+
+  // TODO ----------------------------------------------------
+  debug() // << "------------------------------------\n"
+    << "\nInvariant Imprecision Identification\n"
+    << "------------------------------------\n";
+
+  // getting imprecise ssa variables' names
+  std::vector<std::string> ssa_vars=
+    domain->identify_invariant_imprecision(*result);
+
+  // TODO narrow down later passed stuff if possible
+  find_goto_instrs(SSA, ssa_vars);
+
+  debug() << "------------------------------------\n";
+
+  // ---------------------------------------------------------
+
   delete s_solver;
 }
 
@@ -211,4 +228,171 @@ void ssa_analyzert::update_heap_out(summaryt::var_sett &out)
 const exprt ssa_analyzert::input_heap_bindings()
 {
   return static_cast<heap_domaint &>(*domain).get_iterator_bindings();
+}
+
+/*******************************************************************\
+
+Function: ssa_analyzert::find_goto_instrs
+
+  Inputs: Local SSA, vector of SSA loop back variable names
+
+ Outputs: 
+
+ Purpose: Map the SSA variable names back to the source program.
+
+\*******************************************************************/
+void ssa_analyzert::find_goto_instrs(
+  local_SSAt &SSA, 
+  std::vector<std::string> &ssa_vars)
+{
+  // nth name counter
+  unsigned nth_name=0;
+
+  for (auto &var : ssa_vars)
+  {
+    nth_name++;
+    debug() << nth_name << ": ";
+
+    // heap domain specific, dynamic objects
+    bool is_dynamic=((var.substr(0, DYN_PRFX_LEN-1))=="dynamic_object$");
+
+    // get location of SSA var
+    int loc=get_name_loc(var);
+    if (loc==-1)
+    {
+      debug() << "Input variable\n";
+      continue;
+    }
+
+    // get the pretty name of the imprecise ssa var
+    std::string var_pretty=get_pretty_name(var);
+
+    // get SSA node on that location - end of the loop for loop back var
+    local_SSAt::nodest::iterator lb_node=SSA.find_node(
+      SSA.get_location(static_cast<unsigned>(loc)));
+
+    // get start of the loop node (loophead node) for that node
+    local_SSAt::nodest::iterator lh_node=lb_node->loophead;
+
+    // heap dynamic objects
+    if (is_dynamic)
+    {
+      // getting the object's allocation location
+      int field_loc=get_field_loc(var);
+      if (field_loc==-1)
+      {
+        debug() << "Allocation location not found\n";
+        continue;
+      }
+
+      debug() << "Imprecise value of \"" << get_dynamic_member(var)
+        << "\" field of dynamic object \"" << var << "\" allocated at line "
+        << (SSA.find_node(SSA.get_location(
+          static_cast<unsigned>(field_loc)
+            )))->location->source_location.get_line() << "\n";
+
+      continue;
+    }
+    
+    debug() << "Imprecise value of variable \"" << var_pretty
+      << "\" at the end of the loop, that starts at line "
+      << lh_node->location->source_location.get_line() << "\n";
+  }
+}
+
+/*******************************************************************\
+
+Function: ssa_analyzert::get_name_loc(const std::string &name)
+
+  Inputs: SSA loop back variable name.
+
+ Outputs: Location of the node in the local SSA.
+
+ Purpose: Extract the node location from its ssa name.
+
+\*******************************************************************/
+int ssa_analyzert::get_name_loc(const std::string &name)
+{
+  // find last occurnce of "#lb"
+  size_t idx=name.rfind("#lb");
+  if(idx==std::string::npos)
+    return -1;
+
+  //std::string loc_str=name.substr(name.find_last_not_of("0123456789")+1);
+  std::string loc_str=name.substr(idx+3);
+  assert(!loc_str.empty());
+  return std::stoi(loc_str);
+}
+
+/*******************************************************************\
+
+Function: ssa_analyzert::get_pretty_name(const std::string &name)
+
+  Inputs: SSA loop back variable name.
+
+ Outputs: Pretty name of the SSA variable (only the part before '#').
+
+ Purpose: Strip the name of the part after '#' (and the '#' as well).
+
+\*******************************************************************/
+std::string ssa_analyzert::get_pretty_name(const std::string &name)
+{
+  std::string pretty(name);
+  size_t idx=name.find('#');
+
+  if(idx!=std::string::npos)
+    pretty=name.substr(0, idx);
+  
+  return pretty;
+}
+
+/*******************************************************************\
+
+Function: ssa_analyzert::get_field_loc(const std::string &name)
+
+  Inputs: SSA loop back dynamic variable name.
+
+ Outputs: Location of the field in the local SSA.
+
+ Purpose: Extract the field location from its SSA name.
+
+\*******************************************************************/
+int ssa_analyzert::get_field_loc(const std::string &name)
+{
+  size_t field_pos=name.find_last_of('$');
+  if (field_pos==std::string::npos)
+    return -1;
+
+  std::string loc_str=name.substr(field_pos+1);
+  return std::stoi(loc_str);
+}
+
+/*******************************************************************\
+
+Function: ssa_analyzert::get_dynamic_member(const std::string &name)
+
+  Inputs: SSA loop back dynamic object name.
+
+ Outputs: Member of the dynamic object.
+
+ Purpose: Extract the member field from the dynamic object name.
+
+\*******************************************************************/
+std::string ssa_analyzert::get_dynamic_member(const std::string &name)
+{
+  // only dynamic objects: expecting dollar sign at pos 14
+  assert(name[DYN_PRFX_LEN-2]=='$');
+
+  std::string not_found ("<NO MEMBER>");
+
+  size_t dot_pos=name.find_last_of('.');
+  size_t hash_pos=name.find_last_of('#');
+  if (dot_pos==std::string::npos || hash_pos==std::string::npos)
+    return not_found;
+
+  std::string loc_str=name.substr(dot_pos+1, hash_pos-dot_pos-1);
+  if (loc_str.empty())
+    return not_found;
+
+  return loc_str;
 }

--- a/src/domains/ssa_analyzer.h
+++ b/src/domains/ssa_analyzer.h
@@ -25,6 +25,9 @@ class ssa_analyzert:public messaget
 public:
   typedef strategy_solver_baset::constraintst constraintst;
   typedef strategy_solver_baset::var_listt var_listt;
+  // TODO ------------------------------------------
+  typedef summaryt::imprecise_varst imprecise_varst;
+  // -----------------------------------------------
 
   ssa_analyzert():
     result(NULL),
@@ -62,7 +65,9 @@ public:
   std::string get_pretty_name(const std::string &name);
 
   int get_field_loc(const std::string &name);
-  std::string get_dynamic_member(const std::string &name);
+  std::string get_dynamic_field(const std::string &name);
+
+  imprecise_varst get_imprecise_vars() { return vars_summary; }
   // --------------------------------------------------
 
 protected:
@@ -72,7 +77,9 @@ protected:
   // statistics
   unsigned solver_instances;
   unsigned solver_calls;
+  // TODO ---------------------
+  imprecise_varst vars_summary;
+  // --------------------------
 };
 
 #endif
-

--- a/src/domains/ssa_analyzer.h
+++ b/src/domains/ssa_analyzer.h
@@ -25,9 +25,7 @@ class ssa_analyzert:public messaget
 public:
   typedef strategy_solver_baset::constraintst constraintst;
   typedef strategy_solver_baset::var_listt var_listt;
-  // TODO ------------------------------------------
   typedef summaryt::imprecise_varst imprecise_varst;
-  // -----------------------------------------------
 
   ssa_analyzert():
     result(NULL),
@@ -56,19 +54,16 @@ public:
   inline unsigned get_number_of_solver_instances() { return solver_instances; }
   inline unsigned get_number_of_solver_calls() { return solver_calls; }
 
-  // TODO ---------------------------------------------
   void find_goto_instrs(
-    local_SSAt &SSA, 
-    std::vector<std::string> &ssa_vars);
+    local_SSAt &SSA,
+    const std::vector<std::string> &ssa_vars);
 
-  int get_name_loc(const std::string &name);
-  std::string get_pretty_name(const std::string &name);
+  std::string get_dynobj_name(const std::string &name);
 
-  int get_field_loc(const std::string &name);
-  std::string get_dynamic_field(const std::string &name);
+  int get_name_node_loc(const std::string &name);
 
-  imprecise_varst get_imprecise_vars() { return vars_summary; }
-  // --------------------------------------------------
+  const imprecise_varst &get_imprecise_vars() const
+    { return imprecise_vars_summary; }
 
 protected:
   domaint *domain; // template generator is responsible for the domain object
@@ -77,9 +72,8 @@ protected:
   // statistics
   unsigned solver_instances;
   unsigned solver_calls;
-  // TODO ---------------------
-  imprecise_varst vars_summary;
-  // --------------------------
+
+  imprecise_varst imprecise_vars_summary;
 };
 
 #endif

--- a/src/domains/ssa_analyzer.h
+++ b/src/domains/ssa_analyzer.h
@@ -53,8 +53,20 @@ public:
   inline unsigned get_number_of_solver_instances() { return solver_instances; }
   inline unsigned get_number_of_solver_calls() { return solver_calls; }
 
+  // TODO ---------------------------------------------
+  void find_goto_instrs(
+    local_SSAt &SSA, 
+    std::vector<std::string> &ssa_vars);
+
+  int get_name_loc(const std::string &name);
+  std::string get_pretty_name(const std::string &name);
+
+  int get_field_loc(const std::string &name);
+  std::string get_dynamic_member(const std::string &name);
+  // --------------------------------------------------
+
 protected:
-  domaint *domain; // template generator is responsable for the domain object
+  domaint *domain; // template generator is responsible for the domain object
   domaint::valuet *result;
 
   // statistics

--- a/src/domains/tpolyhedra_domain.cpp
+++ b/src/domains/tpolyhedra_domain.cpp
@@ -890,7 +890,7 @@ std::vector<std::string> tpolyhedra_domaint::identify_invariant_imprecision(
   {
     exprt tmpl_expr=templ[row].expr;
 
-    // only the "maximum" row of both rows is compared
+    // save the name of the first row of the template row pair
     if (first_row)
     {
       first_row_val=get_row_value(row, templ_val);

--- a/src/domains/tpolyhedra_domain.h
+++ b/src/domains/tpolyhedra_domain.h
@@ -151,6 +151,15 @@ public:
 
   void rename_for_row(exprt &expr, const rowt &row);
 
+  // TODO --------------------------------------------------------
+  virtual std::vector<std::string> identify_invariant_imprecision(
+    const valuet &value);
+
+  bool is_row_value_min(
+    const rowt &row,
+    const row_valuet &row_val);
+  // -------------------------------------------------------------
+
 protected:
   friend class strategy_solver_binsearcht;
   friend class strategy_solvert;

--- a/src/domains/tpolyhedra_domain.h
+++ b/src/domains/tpolyhedra_domain.h
@@ -151,14 +151,16 @@ public:
 
   void rename_for_row(exprt &expr, const rowt &row);
 
-  // TODO --------------------------------------------------------
-  virtual std::vector<std::string> identify_invariant_imprecision(
-    const valuet &value);
+  virtual std::vector<std::string>
+    identify_invariant_imprecision(const valuet &value) override;
+
+  bool is_row_value_max(
+    const rowt &row,
+    const row_valuet &row_val);
 
   bool is_row_value_min(
     const rowt &row,
     const row_valuet &row_val);
-  // -------------------------------------------------------------
 
 protected:
   friend class strategy_solver_binsearcht;

--- a/src/domains/util.cpp
+++ b/src/domains/util.cpp
@@ -580,3 +580,45 @@ int get_dynobj_instance(const irep_idt &id)
   std::string number=name.substr(start, end-start);
   return std::stoi(number);
 }
+
+/// \return If the name has a dynamic object's prefix
+bool is_dynamic_name(const std::string &name)
+{
+  return has_prefix(name, "dynamic_object$");
+}
+
+/// retrieve original variable name from ssa variable name
+std::string get_original_name(const std::string &s)
+{
+  size_t pos1=s.find_last_of("#");
+  if(pos1==std::string::npos || (s.substr(pos1+1, 12)=="return_value"))
+    return s;
+  return s.substr(0, pos1);
+}
+
+/// \return Any number > 0 if loopback else std::string::npos
+int is_loopback_var(const std::string &name)
+{
+  return name.rfind("#lb");
+}
+
+/// Extract the member field from the dynamic object name.
+/// \param name: SSA dynamic object name.
+/// \return Structure field name of the dynamic object.
+std::string get_dynamic_field(const std::string &name)
+{
+  std::string not_found("<NO MEMBER>");
+
+  // extract the '_FIELD_' in "dynamic_object$i#k._FIELD_#"
+  size_t dot_pos=name.find('.', DYN_PREFIX_LEN);
+  if(dot_pos==std::string::npos)
+    return not_found;
+
+  size_t hash_pos=name.find('#', dot_pos+1);
+  if(hash_pos==std::string::npos)
+    return not_found;
+
+  std::string field_str=name.substr(dot_pos+1, hash_pos-dot_pos-1);
+  return !field_str.empty() ? field_str : not_found;
+}
+

--- a/src/domains/util.h
+++ b/src/domains/util.h
@@ -19,6 +19,8 @@ Author: Peter Schrammel
 #include <langapi/language_util.h>
 #include <iostream>
 
+#define DYN_PREFIX_LEN 15
+
 void extend_expr_types(exprt &expr);
 constant_exprt simplify_const(const exprt &expr);
 ieee_floatt simplify_const_float(const exprt &expr);
@@ -37,11 +39,16 @@ constant_exprt make_one(const typet &type);
 constant_exprt make_minusone(const typet &type);
 
 irep_idt get_original_name(const symbol_exprt &);
+std::string get_original_name(const std::string &s);
 void clean_expr(exprt &expr);
 
 bool is_cprover_symbol(const exprt &expr);
 
 int get_dynobj_line(const irep_idt &id);
 int get_dynobj_instance(const irep_idt &id);
+
+bool is_dynamic_name(const std::string &name);
+int is_loopback_var(const std::string &name);
+std::string get_dynamic_field(const std::string &name);
 
 #endif

--- a/src/solver/summarizer_fw.cpp
+++ b/src/solver/summarizer_fw.cpp
@@ -167,13 +167,10 @@ void summarizer_fwt::do_summary(
   solver_instances+=analyzer.get_number_of_solver_instances();
   solver_calls+=analyzer.get_number_of_solver_calls();
 
-  // TODO -------------------------------------------------------
-  if (options.get_bool_option("show-imprecise-vars"))
+  if(options.get_bool_option("show-imprecise-vars"))
   {
-    summary.opt_imprecise=true;
     summary.imprecise_vars_summary=analyzer.get_imprecise_vars();
   }
-  // ------------------------------------------------------------
 }
 
 void summarizer_fwt::inline_summaries(

--- a/src/solver/summarizer_fw.cpp
+++ b/src/solver/summarizer_fw.cpp
@@ -166,6 +166,14 @@ void summarizer_fwt::do_summary(
 
   solver_instances+=analyzer.get_number_of_solver_instances();
   solver_calls+=analyzer.get_number_of_solver_calls();
+
+  // TODO -------------------------------------------------------
+  if (options.get_bool_option("show-imprecise-vars"))
+  {
+    summary.opt_imprecise=true;
+    summary.imprecise_vars_summary=analyzer.get_imprecise_vars();
+  }
+  // ------------------------------------------------------------
 }
 
 void summarizer_fwt::inline_summaries(

--- a/src/solver/summary.cpp
+++ b/src/solver/summary.cpp
@@ -68,6 +68,11 @@ void summaryt::output(std::ostream &out, const namespacet &ns) const
 #endif
   out << std::endl;
   out << "terminates: " << threeval2string(terminates) << std::endl;
+
+  // TODO output imprecise variables identified inside forward invariant
+  if (opt_imprecise)
+    out_invariant_imprecise_vars(out);
+  // ---------------------------------
 }
 
 void summaryt::combine_and(exprt &olde, const exprt &newe)
@@ -134,6 +139,67 @@ void summaryt::set_value_domains(const local_SSAt &SSA)
   value_domain_in=SSA.ssa_value_ai[entry_loc];
   value_domain_out=SSA.ssa_value_ai[exit_loc];
 }
+
+/*******************************************************************\
+
+Function: summaryt::out_invariant_imprecise_vars
+
+  Inputs: Output stream
+
+ Outputs:
+
+ Purpose: Outputs statistics about identified imprecise variables 
+          inside generated forward invariant
+
+\*******************************************************************/
+void summaryt::out_invariant_imprecise_vars(std::ostream &out) const
+{
+  out << "invariant imprecise variables:" << std::endl;
+
+  // counter of variables
+  unsigned nth_var=1;
+
+  for (auto &var : imprecise_vars_summary)
+  {
+    out << ' ' << nth_var << ':';
+    nth_var++;
+
+    // does not have a location -> input variable
+    if (var.loophead_loc.empty())
+    {
+      out << " Input variable: \"" << var.pretty_name << '"' << std::endl;
+      continue; 
+    }
+
+    out << " Imprecise value of ";
+    // static variables
+    if (var.dyn_mem_field.empty())
+    {
+      out << "variable \"" << var.pretty_name << '"';
+    }
+    // dynamic variables
+    else
+    {
+      out << '"' << var.dyn_mem_field << "\" field of \"" << var.pretty_name 
+          << "\" allocated at line " << var.dyn_alloc_loc << ';';
+    }
+
+    out << " at the end of the loop; starting at line " << var.loophead_loc 
+        << std::endl;
+  }
+}
+
+/*******************************************************************\
+
+Function: threeval2string
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
 
 std::string threeval2string(threevalt v)
 {

--- a/src/solver/summary.cpp
+++ b/src/solver/summary.cpp
@@ -69,10 +69,9 @@ void summaryt::output(std::ostream &out, const namespacet &ns) const
   out << std::endl;
   out << "terminates: " << threeval2string(terminates) << std::endl;
 
-  // TODO output imprecise variables identified inside forward invariant
-  if (opt_imprecise)
+  // output imprecise variables identified inside forward invariant
+  if(!imprecise_vars_summary.empty())
     out_invariant_imprecise_vars(out);
-  // ---------------------------------
 }
 
 void summaryt::combine_and(exprt &olde, const exprt &newe)
@@ -140,18 +139,9 @@ void summaryt::set_value_domains(const local_SSAt &SSA)
   value_domain_out=SSA.ssa_value_ai[exit_loc];
 }
 
-/*******************************************************************\
-
-Function: summaryt::out_invariant_imprecise_vars
-
-  Inputs: Output stream
-
- Outputs:
-
- Purpose: Outputs statistics about identified imprecise variables 
-          inside generated forward invariant
-
-\*******************************************************************/
+/// Outputs statistics about identified imprecise variables
+///   inside generated forward invariant
+/// \param out: Output stream
 void summaryt::out_invariant_imprecise_vars(std::ostream &out) const
 {
   out << "invariant imprecise variables:" << std::endl;
@@ -159,47 +149,39 @@ void summaryt::out_invariant_imprecise_vars(std::ostream &out) const
   // counter of variables
   unsigned nth_var=1;
 
-  for (auto &var : imprecise_vars_summary)
+  for(auto &var : imprecise_vars_summary)
   {
+    // has no name, no need to print
+    if(var.pretty_name.empty())
+      continue;
+
     out << ' ' << nth_var << ':';
     nth_var++;
 
     // does not have a location -> input variable
-    if (var.loophead_loc.empty())
+    if(var.loophead_line.empty())
     {
       out << " Input variable: \"" << var.pretty_name << '"' << std::endl;
-      continue; 
+      continue;
     }
 
     out << " Imprecise value of ";
     // static variables
-    if (var.dyn_mem_field.empty())
+    if(var.dyn_mem_field.empty())
     {
       out << "variable \"" << var.pretty_name << '"';
     }
     // dynamic variables
     else
     {
-      out << '"' << var.dyn_mem_field << "\" field of \"" << var.pretty_name 
-          << "\" allocated at line " << var.dyn_alloc_loc << ';';
+      out << '"' << var.dyn_mem_field << "\" field of \"" << var.pretty_name
+          << "\" allocated at line " << var.dyn_alloc_line << ';';
     }
 
-    out << " at the end of the loop; starting at line " << var.loophead_loc 
+    out << " at the end of the loop; starting at line " << var.loophead_line
         << std::endl;
   }
 }
-
-/*******************************************************************\
-
-Function: threeval2string
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
 
 std::string threeval2string(threevalt v)
 {

--- a/src/solver/summary.h
+++ b/src/solver/summary.h
@@ -28,17 +28,15 @@ class summaryt
   typedef std::list<symbol_exprt> var_listt;
   typedef std::set<symbol_exprt> var_sett;
 
-  // TODO -------------------------------------------
   typedef struct
   {
-    irep_idt loophead_loc;   // loop-head location
-    irep_idt dyn_mem_field;  // dynamic object memory field name
-    irep_idt dyn_alloc_loc;  // dynamic object allocation location
-    irep_idt pretty_name;    // variable pretty name
+    irep_idt pretty_name;    ///< variable pretty name
+    irep_idt loophead_line;  ///< loop head line number
+    irep_idt dyn_mem_field;  ///< dynamic object memory field name
+    irep_idt dyn_alloc_line; ///< dynamic object allocation line number
   } imprecise_vart;
 
   typedef std::vector<imprecise_vart> imprecise_varst;
-  // -------------------------------------------------
 
   summaryt() :
     fw_precondition(nil_exprt()),
@@ -51,8 +49,7 @@ class summaryt
     aux_precondition(nil_exprt()),
     termination_argument(nil_exprt()),
     terminates(UNKNOWN),
-    mark_recompute(false),
-    opt_imprecise(false) {}
+    mark_recompute(false) {}
 
   var_listt params;
   var_sett globals_in, globals_out;
@@ -74,19 +71,15 @@ class summaryt
   bool mark_recompute; // to force recomputation of the summary
                        // (used for invariant reuse in k-induction)
 
-  // TODO ---------------------------------------------------
   imprecise_varst imprecise_vars_summary;
-
-  bool opt_imprecise;   // whether the imprecise vars header should be output
-
-  void out_invariant_imprecise_vars(std::ostream &out) const;
-  // --------------------------------------------------------
 
   void output(std::ostream &out, const namespacet &ns) const;
 
   void join(const summaryt &new_summary);
 
   void set_value_domains(const local_SSAt &SSA);
+
+  void out_invariant_imprecise_vars(std::ostream &out) const;
 
  protected:
   void combine_or(exprt &olde, const exprt &newe);

--- a/src/solver/summary.h
+++ b/src/solver/summary.h
@@ -28,6 +28,18 @@ class summaryt
   typedef std::list<symbol_exprt> var_listt;
   typedef std::set<symbol_exprt> var_sett;
 
+  // TODO -------------------------------------------
+  typedef struct
+  {
+    irep_idt loophead_loc;   // loop-head location
+    irep_idt dyn_mem_field;  // dynamic object memory field name
+    irep_idt dyn_alloc_loc;  // dynamic object allocation location
+    irep_idt pretty_name;    // variable pretty name
+  } imprecise_vart;
+
+  typedef std::vector<imprecise_vart> imprecise_varst;
+  // -------------------------------------------------
+
   summaryt() :
     fw_precondition(nil_exprt()),
     fw_transformer(nil_exprt()),
@@ -39,7 +51,8 @@ class summaryt
     aux_precondition(nil_exprt()),
     termination_argument(nil_exprt()),
     terminates(UNKNOWN),
-    mark_recompute(false) {}
+    mark_recompute(false),
+    opt_imprecise(false) {}
 
   var_listt params;
   var_sett globals_in, globals_out;
@@ -60,6 +73,14 @@ class summaryt
 
   bool mark_recompute; // to force recomputation of the summary
                        // (used for invariant reuse in k-induction)
+
+  // TODO ---------------------------------------------------
+  imprecise_varst imprecise_vars_summary;
+
+  bool opt_imprecise;   // whether the imprecise vars header should be output
+
+  void out_invariant_imprecise_vars(std::ostream &out) const;
+  // --------------------------------------------------------
 
   void output(std::ostream &out, const namespacet &ns) const;
 


### PR DESCRIPTION
Invariant imprecision identification methods for domains:
 tpolyhedra (intervals domain), heap, heap tpolyhedra, heap tpolyhedra sympath

Option "--show-imprecise-vars" outputs information about identified variables causing imprecisions for each analyzed function.

Latest revisions include:
- latest 2ls base repository commits
- cleaned code, revised comments and names
- conversion to doxygen comments (as is seen in latest commits)